### PR TITLE
Add UNIX timestamp to images to force browser cache invalidation

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -151,6 +151,8 @@ class Blockreassurance extends Module implements WidgetInterface
     {
         $html = '';
         $id_reassurance = (int)Tools::getValue('id_reassurance');
+        $date = new DateTime();
+        $timestamp = $date->getTimestamp();
 
         if (Tools::isSubmit('saveblockreassurance')) {
             if ($id_reassurance = Tools::getValue('id_reassurance')) {
@@ -170,12 +172,12 @@ class Blockreassurance extends Module implements WidgetInterface
                         return false;
                     } elseif (!($tmpName = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !move_uploaded_file($_FILES['image']['tmp_name'], $tmpName)) {
                         return false;
-                    } elseif (!ImageManager::resize($tmpName, dirname(__FILE__).'/img/reassurance-'.(int)$reassurance->id.'-'.(int)$reassurance->id_shop.'.jpg')) {
+                    } elseif (!ImageManager::resize($tmpName, dirname(__FILE__).'/img/reassurance-'.(int)$reassurance->id.'-'.(int)$reassurance->id_shop.'-'.$timestamp.'.jpg')) {
                         return false;
                     }
 
                     unlink($tmpName);
-                    $reassurance->file_name = 'reassurance-'.(int)$reassurance->id.'-'.(int)$reassurance->id_shop.'.jpg';
+                    $reassurance->file_name = 'reassurance-'.(int)$reassurance->id.'-'.(int)$reassurance->id_shop.'-'.$timestamp.'.jpg';
                     $reassurance->save();
                 }
                 $this->_clearCache('*');


### PR DESCRIPTION
When replacing a reassurance item image, the new image has the same filename as the one it replaces meaning that the changes won't take effect client side without the user Ctrl+F5'ing the page. This PR adds an unique timestamp to each filename, to fix this issue.